### PR TITLE
Allow '-' to be passed as input and output.

### DIFF
--- a/minisat/core/Solver.cc
+++ b/minisat/core/Solver.cc
@@ -737,7 +737,7 @@ lbool Solver::search(int nof_conflicts)
                 max_learnts             *= learntsize_inc;
 
                 if (verbosity >= 1)
-                    printf("| %9d | %7d %8d %8d | %8d %8d %6.0f | %6.3f %% |\n", 
+                    fprintf(stderr, "| %9d | %7d %8d %8d | %8d %8d %6.0f | %6.3f %% |\n", 
                            (int)conflicts, 
                            (int)dec_vars - (trail_lim.size() == 0 ? trail.size() : trail_lim[0]), nClauses(), (int)clauses_literals, 
                            (int)max_learnts, nLearnts(), (double)learnts_literals/nLearnts(), progressEstimate()*100);
@@ -853,10 +853,10 @@ lbool Solver::solve_()
     lbool   status            = l_Undef;
 
     if (verbosity >= 1){
-        printf("============================[ Search Statistics ]==============================\n");
-        printf("| Conflicts |          ORIGINAL         |          LEARNT          | Progress |\n");
-        printf("|           |    Vars  Clauses Literals |    Limit  Clauses Lit/Cl |          |\n");
-        printf("===============================================================================\n");
+        fprintf(stderr, "============================[ Search Statistics ]==============================\n");
+        fprintf(stderr, "| Conflicts |          ORIGINAL         |          LEARNT          | Progress |\n");
+        fprintf(stderr, "|           |    Vars  Clauses Literals |    Limit  Clauses Lit/Cl |          |\n");
+        fprintf(stderr, "===============================================================================\n");
     }
 
     // Search:
@@ -869,7 +869,7 @@ lbool Solver::solve_()
     }
 
     if (verbosity >= 1)
-        printf("===============================================================================\n");
+        fprintf(stderr, "===============================================================================\n");
 
 
     if (status == l_True){
@@ -984,7 +984,7 @@ void Solver::toDimacs(FILE* f, const vec<Lit>& assumps)
         toDimacs(f, ca[clauses[i]], map, max);
 
     if (verbosity > 0)
-        printf("Wrote DIMACS with %d variables and %d clauses.\n", max, cnt);
+        fprintf(stderr, "Wrote DIMACS with %d variables and %d clauses.\n", max, cnt);
 }
 
 
@@ -992,13 +992,13 @@ void Solver::printStats() const
 {
     double cpu_time = cpuTime();
     double mem_used = memUsedPeak();
-    printf("restarts              : %"PRIu64"\n", starts);
-    printf("conflicts             : %-12"PRIu64"   (%.0f /sec)\n", conflicts   , conflicts   /cpu_time);
-    printf("decisions             : %-12"PRIu64"   (%4.2f %% random) (%.0f /sec)\n", decisions, (float)rnd_decisions*100 / (float)decisions, decisions   /cpu_time);
-    printf("propagations          : %-12"PRIu64"   (%.0f /sec)\n", propagations, propagations/cpu_time);
-    printf("conflict literals     : %-12"PRIu64"   (%4.2f %% deleted)\n", tot_literals, (max_literals - tot_literals)*100 / (double)max_literals);
-    if (mem_used != 0) printf("Memory used           : %.2f MB\n", mem_used);
-    printf("CPU time              : %g s\n", cpu_time);
+    fprintf(stderr, "restarts              : %"PRIu64"\n", starts);
+    fprintf(stderr, "conflicts             : %-12"PRIu64"   (%.0f /sec)\n", conflicts   , conflicts   /cpu_time);
+    fprintf(stderr, "decisions             : %-12"PRIu64"   (%4.2f %% random) (%.0f /sec)\n", decisions, (float)rnd_decisions*100 / (float)decisions, decisions   /cpu_time);
+    fprintf(stderr, "propagations          : %-12"PRIu64"   (%.0f /sec)\n", propagations, propagations/cpu_time);
+    fprintf(stderr, "conflict literals     : %-12"PRIu64"   (%4.2f %% deleted)\n", tot_literals, (max_literals - tot_literals)*100 / (double)max_literals);
+    if (mem_used != 0) fprintf(stderr, "Memory used           : %.2f MB\n", mem_used);
+    fprintf(stderr, "CPU time              : %g s\n", cpu_time);
 }
 
 
@@ -1060,7 +1060,7 @@ void Solver::garbageCollect()
 
     relocAll(to);
     if (verbosity >= 2)
-        printf("|  Garbage collection:   %12d bytes => %12d bytes             |\n", 
+        fprintf(stderr, "|  Garbage collection:   %12d bytes => %12d bytes             |\n", 
                ca.size()*ClauseAllocator::Unit_Size, to.size()*ClauseAllocator::Unit_Size);
     to.moveTo(ca);
 }

--- a/minisat/simp/SimpSolver.cc
+++ b/minisat/simp/SimpSolver.cc
@@ -130,7 +130,7 @@ lbool SimpSolver::solve_(bool do_simp, bool turn_off_simp)
     if (result == l_True)
         result = Solver::solve_();
     else if (verbosity >= 1)
-        printf("===============================================================================\n");
+        fprintf(stderr, "===============================================================================\n");
 
     if (result == l_True && extend_model)
         extendModel();
@@ -366,7 +366,7 @@ bool SimpSolver::backwardSubsumptionCheck(bool verbose)
         if (c.mark()) continue;
 
         if (verbose && verbosity >= 2 && cnt++ % 1000 == 0)
-            printf("subsumption left: %10d (%10d subsumed, %10d deleted literals)\r", subsumption_queue.size(), subsumed, deleted_literals);
+            fprintf(stderr, "subsumption left: %10d (%10d subsumed, %10d deleted literals)\r", subsumption_queue.size(), subsumed, deleted_literals);
 
         assert(c.size() > 1 || value(c[0]) == l_True);    // Unit-clauses should have been propagated before this point.
 
@@ -604,7 +604,7 @@ bool SimpSolver::eliminate(bool turn_off_elim)
     while (n_touched > 0 || bwdsub_assigns < trail.size() || elim_heap.size() > 0){
 
         gatherTouchedClauses();
-        // printf("  ## (time = %6.2f s) BWD-SUB: queue = %d, trail = %d\n", cpuTime(), subsumption_queue.size(), trail.size() - bwdsub_assigns);
+        // fprintf(stderr, "  ## (time = %6.2f s) BWD-SUB: queue = %d, trail = %d\n", cpuTime(), subsumption_queue.size(), trail.size() - bwdsub_assigns);
         if ((subsumption_queue.size() > 0 || bwdsub_assigns < trail.size()) && 
             !backwardSubsumptionCheck(true)){
             ok = false; goto cleanup; }
@@ -617,7 +617,7 @@ bool SimpSolver::eliminate(bool turn_off_elim)
             elim_heap.clear();
             goto cleanup; }
 
-        // printf("  ## (time = %6.2f s) ELIM: vars = %d\n", cpuTime(), elim_heap.size());
+        // fprintf(stderr, "  ## (time = %6.2f s) ELIM: vars = %d\n", cpuTime(), elim_heap.size());
         for (int cnt = 0; !elim_heap.empty(); cnt++){
             Var elim = elim_heap.removeMin();
             
@@ -626,7 +626,7 @@ bool SimpSolver::eliminate(bool turn_off_elim)
             if (isEliminated(elim) || value(elim) != l_Undef) continue;
 
             if (verbosity >= 2 && cnt % 100 == 0)
-                printf("elimination left: %10d\r", elim_heap.size());
+                fprintf(stderr, "elimination left: %10d\r", elim_heap.size());
 
             if (use_asymm){
                 // Temporarily freeze variable. Otherwise, it would immediately end up on the queue again:
@@ -670,7 +670,7 @@ bool SimpSolver::eliminate(bool turn_off_elim)
     }
 
     if (verbosity >= 1 && elimclauses.size() > 0)
-        printf("|  Eliminated clauses:     %10.2f Mb                                      |\n", 
+        fprintf(stderr, "|  Eliminated clauses:     %10.2f Mb                                      |\n", 
                double(elimclauses.size() * sizeof(uint32_t)) / (1024*1024));
 
     return ok;
@@ -719,7 +719,7 @@ void SimpSolver::garbageCollect()
     relocAll(to);
     Solver::relocAll(to);
     if (verbosity >= 2)
-        printf("|  Garbage collection:   %12d bytes => %12d bytes             |\n", 
+        fprintf(stderr, "|  Garbage collection:   %12d bytes => %12d bytes             |\n", 
                ca.size()*ClauseAllocator::Unit_Size, to.size()*ClauseAllocator::Unit_Size);
     to.moveTo(ca);
 }

--- a/minisat/utils/Options.cc
+++ b/minisat/utils/Options.cc
@@ -39,10 +39,12 @@ void Minisat::parseOptions(int& argc, char** argv, bool strict)
             for (int k = 0; !parsed_ok && k < Option::getOptionList().size(); k++){
                 parsed_ok = Option::getOptionList()[k]->parse(argv[i]);
 
-                // fprintf(stderr, "checking %d: %s against flag <%s> (%s)\n", i, argv[i], Option::getOptionList()[k]->name, parsed_ok ? "ok" : "skip");
+                //fprintf(stderr, "checking %d: %s against flag <%s> (%s)\n", i, argv[i], Option::getOptionList()[k]->name, parsed_ok ? "ok" : "skip");
             }
 
             if (!parsed_ok){
+    	        if (strcmp(argv[i], "-") == 0)
+                    break;
                 if (strict && match(argv[i], "-"))
                     fprintf(stderr, "ERROR! Unknown flag \"%s\". Use '--%shelp' for help.\n", argv[i], Option::getHelpPrefixString()), exit(1);
                 else

--- a/minisat/utils/System.cc
+++ b/minisat/utils/System.cc
@@ -41,7 +41,7 @@ static inline int memReadStat(int field)
 
     for (; field >= 0; field--)
         if (fscanf(in, "%d", &value) != 1)
-            printf("ERROR! Failed to parse memory statistics from \"/proc\".\n"), exit(1);
+            fprintf(stderr, "ERROR! Failed to parse memory statistics from \"/proc\".\n"), exit(1);
     fclose(in);
     return value;
 }
@@ -101,7 +101,7 @@ void Minisat::setX86FPUPrecision()
     // Only correct FPU precision on Linux architectures that needs and supports it:
     fpu_control_t oldcw, newcw;
     _FPU_GETCW(oldcw); newcw = (oldcw & ~_FPU_EXTENDED) | _FPU_DOUBLE; _FPU_SETCW(newcw);
-    printf("WARNING: for repeatability, setting FPU to use double precision\n");
+    fprintf(stderr, "WARNING: for repeatability, setting FPU to use double precision\n");
 #endif
 }
 
@@ -122,7 +122,7 @@ void Minisat::limitMemory(uint64_t max_mem_mb)
         if (rl.rlim_max == RLIM_INFINITY || new_mem_lim < rl.rlim_max){
             rl.rlim_cur = new_mem_lim;
             if (setrlimit(RLIMIT_AS, &rl) == -1)
-                printf("WARNING! Could not set resource limit: Virtual memory.\n");
+                fprintf(stderr, "WARNING! Could not set resource limit: Virtual memory.\n");
         }
     }
 
@@ -133,7 +133,7 @@ void Minisat::limitMemory(uint64_t max_mem_mb)
 #else
 void Minisat::limitMemory(uint64_t /*max_mem_mb*/)
 {
-    printf("WARNING! Memory limit not supported on this architecture.\n");
+    fprintf(stderr, "WARNING! Memory limit not supported on this architecture.\n");
 }
 #endif
 
@@ -147,14 +147,14 @@ void Minisat::limitTime(uint32_t max_cpu_time)
         if (rl.rlim_max == RLIM_INFINITY || (rlim_t)max_cpu_time < rl.rlim_max){
             rl.rlim_cur = max_cpu_time;
             if (setrlimit(RLIMIT_CPU, &rl) == -1)
-                printf("WARNING! Could not set resource limit: CPU-time.\n");
+                fprintf(stderr, "WARNING! Could not set resource limit: CPU-time.\n");
         }
     }
 }
 #else
 void Minisat::limitTime(uint32_t /*max_cpu_time*/)
 {
-    printf("WARNING! CPU-time limit not supported on this architecture.\n");
+    fprintf(stderr, "WARNING! CPU-time limit not supported on this architecture.\n");
 }
 #endif
 


### PR DESCRIPTION
Separate input and output and allow '-' symbols to be passed as
the names of files specifying that stdin and stdout should be used
for input and output respecitvely.

Also move all debug/verbose and other service output from stdout
to stderr to allow the complete solution be passed to stdout.

This patch allows minisat to be incorporated with other unix utilites
that uses pipes for communication and not files.
