### PR TITLE
Fixed "memUsedPeak not defined" bug on Mac OSX

### DIFF
--- a/minisat/utils/System.cc
+++ b/minisat/utils/System.cc
@@ -87,7 +87,7 @@ double Minisat::memUsed() {
     malloc_statistics_t t;
     malloc_zone_statistics(NULL, &t);
     return (double)t.max_size_in_use / (1024*1024); }
-double Minisat::memUsedPeak() { return memUsed(); }
+double Minisat::memUsedPeak(bool strictlyPeak) { return memUsed(); }
 
 #else
 double Minisat::memUsed()     { return 0; }

--- a/minisat/utils/System.cc
+++ b/minisat/utils/System.cc
@@ -77,7 +77,7 @@ double Minisat::memUsed() {
     struct rusage ru;
     getrusage(RUSAGE_SELF, &ru);
     return (double)ru.ru_maxrss / 1024; }
-double Minisat::memUsedPeak() { return memUsed(); }
+double Minisat::memUsedPeak(bool strictlyPeak) { return memUsed(); }
 
 
 #elif defined(__APPLE__)
@@ -91,7 +91,7 @@ double Minisat::memUsedPeak(bool strictlyPeak) { return memUsed(); }
 
 #else
 double Minisat::memUsed()     { return 0; }
-double Minisat::memUsedPeak() { return 0; }
+double Minisat::memUsedPeak(bool strictlyPeak) { return 0; }
 #endif
 
 


### PR DESCRIPTION
Fix for this issue: https://github.com/niklasso/minisat/issues/1
