### PR TITLE
Fix compilation for non-linux OS's

### DIFF
--- a/minisat/core/Dimacs.h
+++ b/minisat/core/Dimacs.h
@@ -24,6 +24,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #include <stdio.h>
 
 #include "minisat/utils/ParseUtils.h"
+#include "minisat/utils/StreamBuffer.h"
 #include "minisat/core/SolverTypes.h"
 
 namespace Minisat {

--- a/minisat/core/Solver.cc
+++ b/minisat/core/Solver.cc
@@ -18,6 +18,12 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
+// It seems that we trigger a compiler bug in MinGW in the code below, so
+// turn off the optimisations for now
+#if defined(__MINGW32__)
+#pragma GCC optimize "O0"
+#endif
+
 #include <math.h>
 
 #include "minisat/mtl/Alg.h"

--- a/minisat/core/SolverTypes.h
+++ b/minisat/core/SolverTypes.h
@@ -51,16 +51,13 @@ typedef int Var;
 struct Lit {
     int     x;
 
-    // Use this as a constructor:
-    friend Lit mkLit(Var var, bool sign = false);
-
     bool operator == (Lit p) const { return x == p.x; }
     bool operator != (Lit p) const { return x != p.x; }
     bool operator <  (Lit p) const { return x < p.x;  } // '<' makes p, ~p adjacent in the ordering.
 };
 
 
-inline  Lit  mkLit     (Var var, bool sign) { Lit p; p.x = var + var + (int)sign; return p; }
+inline  Lit  mkLit     (Var var, bool sign = false) { Lit p; p.x = var + var + (int)sign; return p; }
 inline  Lit  operator ~(Lit p)              { Lit q; q.x = p.x ^ 1; return q; }
 inline  Lit  operator ^(Lit p, bool b)      { Lit q; q.x = p.x ^ (unsigned int)b; return q; }
 inline  bool sign      (Lit p)              { return p.x & 1; }

--- a/minisat/utils/StreamBuffer.h
+++ b/minisat/utils/StreamBuffer.h
@@ -1,4 +1,4 @@
-/************************************************************************************[ParseUtils.h]
+/**********************************************************************************[StreamBuffer.h]
 Copyright (c) 2003-2006, Niklas Een, Niklas Sorensson
 Copyright (c) 2007-2010, Niklas Sorensson
 
@@ -18,76 +18,50 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
-#ifndef Minisat_ParseUtils_h
-#define Minisat_ParseUtils_h
+#ifndef Minisat_StreamBuffer_h
+#define Minisat_StreamBuffer_h
 
 #include <stdlib.h>
 #include <stdio.h>
+
+#include <zlib.h>
 
 #include "minisat/mtl/XAlloc.h"
 
 namespace Minisat {
 
+//-------------------------------------------------------------------------------------------------
+// A simple buffered character stream class:
+
+class StreamBuffer {
+    gzFile         in;
+    unsigned char* buf;
+    int            pos;
+    int            size;
+
+    enum { buffer_size = 64*1024 };
+
+    void assureLookahead() {
+        if (pos >= size) {
+            pos  = 0;
+            size = gzread(in, buf, buffer_size); } }
+
+public:
+    explicit StreamBuffer(gzFile i) : in(i), pos(0), size(0){
+        buf = (unsigned char*)xrealloc(NULL, buffer_size);
+        assureLookahead();
+    }
+    ~StreamBuffer() { free(buf); }
+
+    int  operator *  () const { return (pos >= size) ? EOF : buf[pos]; }
+    void operator ++ ()       { pos++; assureLookahead(); }
+    int  position    () const { return pos; }
+};
 
 //-------------------------------------------------------------------------------------------------
-// End-of-file detection functions for char*:
+// End-of-file detection functions for StreamBuffer:
 
-static inline bool isEof(const char*   in) { return *in == '\0'; }
-
-//-------------------------------------------------------------------------------------------------
-// Generic parse functions parametrized over the input-stream type.
-
-
-template<class B>
-static void skipWhitespace(B& in) {
-    while ((*in >= 9 && *in <= 13) || *in == 32)
-        ++in; }
-
-
-template<class B>
-static void skipLine(B& in) {
-    for (;;){
-        if (isEof(in)) return;
-        if (*in == '\n') { ++in; return; }
-        ++in; } }
-
-
-template<class B>
-static int parseInt(B& in) {
-    int     val = 0;
-    bool    neg = false;
-    skipWhitespace(in);
-    if      (*in == '-') neg = true, ++in;
-    else if (*in == '+') ++in;
-    if (*in < '0' || *in > '9') fprintf(stderr, "PARSE ERROR! Unexpected char: %c\n", *in), exit(3);
-    while (*in >= '0' && *in <= '9')
-        val = val*10 + (*in - '0'),
-        ++in;
-    return neg ? -val : val; }
-
-
-// String matching: in case of a match the input iterator will be advanced the corresponding
-// number of characters.
-template<class B>
-static bool match(B& in, const char* str) {
-    int i;
-    for (i = 0; str[i] != '\0'; i++)
-        if (in[i] != str[i])
-            return false;
-
-    in += i;
-
-    return true; 
-}
-
-// String matching: consumes characters eagerly, but does not require random access iterator.
-template<class B>
-static bool eagerMatch(B& in, const char* str) {
-    for (; *str != '\0'; ++str, ++in)
-        if (*str != *in)
-            return false;
-    return true; }
-
+static inline bool isEof(StreamBuffer& in) { return *in == EOF;  }
 
 //=================================================================================================
 }

--- a/minisat/utils/System.cc
+++ b/minisat/utils/System.cc
@@ -77,7 +77,7 @@ double Minisat::memUsed() {
     struct rusage ru;
     getrusage(RUSAGE_SELF, &ru);
     return (double)ru.ru_maxrss / 1024; }
-double Minisat::memUsedPeak() { return memUsed(); }
+double Minisat::memUsedPeak(bool) { return memUsed(); }
 
 
 #elif defined(__APPLE__)
@@ -87,11 +87,11 @@ double Minisat::memUsed() {
     malloc_statistics_t t;
     malloc_zone_statistics(NULL, &t);
     return (double)t.max_size_in_use / (1024*1024); }
-double Minisat::memUsedPeak() { return memUsed(); }
+double Minisat::memUsedPeak(bool) { return memUsed(); }
 
 #else
 double Minisat::memUsed()     { return 0; }
-double Minisat::memUsedPeak() { return 0; }
+double Minisat::memUsedPeak(bool) { return 0; }
 #endif
 
 


### PR DESCRIPTION
A bool parameter was added to memUsedPeak, but not to the code of all os's != linux so compilation fails on Windows and Mac without this change
