### PR TITLE
Make the default binary statically linked.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,9 +191,9 @@ install-lib: $(BUILD_DIR)/release/lib/$(MINISAT_SLIB) $(BUILD_DIR)/dynamic/lib/$
 	ln -sf $(MINISAT_DLIB).$(SOMAJOR) $(DESTDIR)$(libdir)/$(MINISAT_DLIB)
 	$(INSTALL) -m 644 $(BUILD_DIR)/release/lib/$(MINISAT_SLIB) $(DESTDIR)$(libdir)
 
-install-bin: $(BUILD_DIR)/dynamic/bin/$(MINISAT)
+install-bin: $(BUILD_DIR)/release/bin/$(MINISAT)
 	$(INSTALL) -d $(DESTDIR)$(bindir)
-	$(INSTALL) -m 755 $(BUILD_DIR)/dynamic/bin/$(MINISAT) $(DESTDIR)$(bindir)
+	$(INSTALL) -m 755 $(BUILD_DIR)/release/bin/$(MINISAT) $(DESTDIR)$(bindir)
 
 clean:
 	rm -f $(foreach t, release debug profile dynamic, $(foreach o, $(SRCS:.cc=.o), $(BUILD_DIR)/$t/$o)) \


### PR DESCRIPTION
The default binary was dynamically linked (_dynamic_ target instead of
_release_ target), but this meant that the default binary failed to
run if LD_LIBRARY_PATH was not set, when PREFIX was set to a
non-default value. In other words, installing minisat into your home
dir resulted in a binary that would not run out of the box.  The
problem is that the dynamically linked minisat binary depends on
libminisat.

I ran into this while trying to install tip from source: it needed a
newer version of minisat than my package manager provided.
